### PR TITLE
Modified filtering for inventory table

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -20,7 +20,9 @@ class DataTable extends React.Component {
                   Header: "Item",
                   accessor: row => `${row.Item}`,
                   filterMethod: (filter, row) => {
-                    return row._original.Item.startsWith(filter.value);
+                    return row._original.Item.toLowerCase().includes(
+                      filter.value
+                    );
                   }
                 }
               ]

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -21,7 +21,7 @@ class DataTable extends React.Component {
                   accessor: row => `${row.Item}`,
                   filterMethod: (filter, row) => {
                     return row._original.Item.toLowerCase().includes(
-                      filter.value
+                      filter.value.toLowerCase()
                     );
                   }
                 }


### PR DESCRIPTION
solves issue #56 
inventory table filtering ignores case and checks for substring (instead of just start of name)